### PR TITLE
Fix single switch mininet default arguments

### DIFF
--- a/docker/scripts/mininet/single_switch_mininet.py
+++ b/docker/scripts/mininet/single_switch_mininet.py
@@ -42,9 +42,9 @@ parser.add_argument('--log-file', help='Path to write the switch log file',
 parser.add_argument('--pcap-dump', help='Dump packets on interfaces to pcap files',
                    action="store_true")
 parser.add_argument('--switch-config', help='simple_switch_CLI script to configure switch',
-                    type=str, action="store", required=False, default=False)
+                    type=str, action="store", required=False)
 parser.add_argument('--cli-message', help='Message to print before starting CLI',
-                    type=str, action="store", required=False, default=False)
+                    type=str, action="store", required=False)
 
 args = parser.parse_args()
 


### PR DESCRIPTION
The default argument for --switch-config and --cli-message were
'False', but the code that checks for their presence compares
against 'None'.

This changes the default argument to be 'None'.

---

To test this change, try running
```
> cp ../../../examples/simple_router.p4app/* .
> p4c-bm2-ss simple_router.p4 -o simple_router.json
> sudo ./single_switch_mininet.py --behavioral-exe simple_switch --json simple_router.json
```
from within `scripts/mininet`